### PR TITLE
Move colors to sub-panel tab for WooCommerce in Customizer

### DIFF
--- a/includes/class-wc-colors-customizer.php
+++ b/includes/class-wc-colors-customizer.php
@@ -37,10 +37,8 @@ class WC_Colors_Customizer {
 	public function register_settings( $wp_customize ) {
 
 		$wp_customize->add_section( $this->section_slug, array(
-			'title'       => __( 'WooCommerce', 'woocommerce-colors' ),
 			'title'       => __( 'Colors', 'woocommerce-colors' ),
 			'priority'    => 60,
-			'description' => __( 'WooCommerce Colors.', 'woocommerce-colors' )
 			'description' => __( 'WooCommerce Colors.', 'woocommerce-colors' ),
 			'panel'       => 'woocommerce',
 		) );

--- a/includes/class-wc-colors-customizer.php
+++ b/includes/class-wc-colors-customizer.php
@@ -38,8 +38,11 @@ class WC_Colors_Customizer {
 
 		$wp_customize->add_section( $this->section_slug, array(
 			'title'       => __( 'WooCommerce', 'woocommerce-colors' ),
+			'title'       => __( 'Colors', 'woocommerce-colors' ),
 			'priority'    => 60,
 			'description' => __( 'WooCommerce Colors.', 'woocommerce-colors' )
+			'description' => __( 'WooCommerce Colors.', 'woocommerce-colors' ),
+			'panel'       => 'woocommerce',
 		) );
 
 		// Primary Color.


### PR DESCRIPTION
Previously, this plugin would add it's own "WooCommerce" tab to the Customizer, which would become confusing/redundant when WooCommerce set up it's own section within the Customizer.

This PR moves the colors to a sub-panel of the WooCommerce tab within the Customizer.