### PR TITLE
update wordpress.org contributor list, sync readme with wordpress.org

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce Colors ===
-Contributors: woothemes, claudiosanches
+Contributors: woocommerce, automattic, woothemes, claudiosanches
 Tags: woocommerce, shortcodes
 Requires at least: 4.0
-Tested up to: 4.9
+Tested up to: 5.5
 Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This PR updates the WordPress.org `readme.txt` to make `woocommerce` the `Developer` of the plugin.

ref: p1596823265254600-sl